### PR TITLE
 Use bootstrap sizing instead of grid-system for repo tables

### DIFF
--- a/src/api/app/views/webui2/shared/_repositories_flag_table.html.haml
+++ b/src/api/app/views/webui2/shared/_repositories_flag_table.html.haml
@@ -2,10 +2,10 @@
   %table.table.table-hover
     %thead.thead-light
       %tr
-        %th.col-6 Repository
-        %th.col-2.text-center All
+        %th.w-auto Repository
+        %th.w-auto.text-center All
         - architectures.each do |architecture|
-          %th.col-2.text-center= architecture.name
+          %th.w-auto.text-center= architecture.name
     %tbody
       %tr
         %td.reponame


### PR DESCRIPTION
Bootstrap grid-system does not work in chrome for tables